### PR TITLE
Wip friedliche

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -86,26 +86,28 @@ hell_mv() {
 		filename_dst="${arr[1]##*/}"
 		dst_name="${filename_dst%%.*}"
 
-		dir=$(dirname "${arr[1]}")
-		files=($dir/*."${exts[1]}")
+		dir_dst=$(dirname "${arr[1]}")
+		files_dst=($dir_dst/*."${exts[1]}")
 
 		filename_src="${arr[0]##*/}"
-		if [[ ! "${files[@]}" =~ "$filename_src" ]]; then
-			echo "File '$filename_src' not in directory '$dir'."
+		dir_src=$(dirname "${arr[0]}")
+		files_src=($dir_src/*."${exts[1]}")
+		if [[ ! "${files_src[@]}" =~ "$filename_src" ]]; then
+			echo "File '$filename_src' not in directory '$dir_src'."
 			return 0
 		fi
 
-		count=$(ls "$dir"/*."${exts[1]}" | wc -l)
+		count=$(ls "$dir_dst"/*."${exts[1]}" | wc -l)
 
 		readarray randarr < <(seq "$count" | shuf)		
 
 		echo ${randarr[@]}
-		echo ${files[@]}
+		echo ${files_dst[@]}
 		for ((i=0;i<count;i++)); do
-			filename="${files[i]}"
+			filename="${files_dst[i]}"
 
-			if [[ "${files[@]}" =~ "${dst_name}${randarr[i]%?}"."${exts[1]}" ]]; then 
-				new_c=$(( count + $i ))
+			if [[ "${files_dst[@]}" =~ "${dst_name}${randarr[i]%?}"."${exts[1]}" ]]; then 
+				new_c=$(( count + 1 + $i ))
 				mv "$filename" "${dst_name}${new_c}"."${exts[1]}"
 				continue
 			fi

--- a/.bashrc
+++ b/.bashrc
@@ -104,6 +104,11 @@ hell_mv() {
 		for ((i=0;i<count;i++)); do
 			filename="${files[i]}"
 
+			if [[ "${files[@]}" =~ "${dst_name}${randarr[i]%?}"."${exts[1]}" ]]; then 
+				new_c=$(( count + $i ))
+				mv "$filename" "${dst_name}${new_c}"."${exts[1]}"
+				continue
+			fi
 			mv "$filename" "${dst_name}${randarr[i]%?}"."${exts[1]}"
 		done	
 	else

--- a/.bashrc
+++ b/.bashrc
@@ -6,6 +6,7 @@ alias nano1=hell_nano
 alias exec1=hell_exec
 alias echo1=hell_echo
 alias touch1=hell_touch
+alias mv1=hell_mv
 
 hell_ls() {
 	args="$@"
@@ -65,6 +66,51 @@ hell_touch() {
 		return 0
 	fi
 	mkdir -p .files && touch .files/"${filename}"
+}
+
+hell_mv() {
+	arr=( "$@" )
+	declare -a exts
+	declare -a randarr
+
+	for arg in "${arr[@]}"; do
+		filename="${arg##*/}"
+
+		count=$(echo "$filename" | grep -o "\." | wc -l)
+		if [ "$count" -gt 0 ]; then
+			exts=("${filename#*.}" "${exts[@]}")
+		fi		
+	done
+
+	if [ "${exts[0]}" == "${exts[1]}" ]; then
+		filename_dst="${arr[1]##*/}"
+		dst_name="${filename_dst%%.*}"
+
+		dir=$(dirname "${arr[1]}")
+		files=($dir/*."${exts[1]}")
+
+		filename_src="${arr[0]##*/}"
+		if [[ ! "${files[@]}" =~ "$filename_src" ]]; then
+			echo "File '$filename_src' not in directory '$dir'."
+			return 0
+		fi
+
+		count=$(ls "$dir"/*."${exts[1]}" | wc -l)
+
+		readarray randarr < <(seq "$count" | shuf)		
+
+		echo ${randarr[@]}
+		echo ${files[@]}
+		for ((i=0;i<count;i++)); do
+			filename="${files[i]}"
+
+			mv "$filename" "${dst_name}${randarr[i]%?}"."${exts[1]}"
+		done	
+	else
+		echo "Try to mv to a file with same extension."
+		return 0
+	fi
+	
 }
 
 random(){


### PR DESCRIPTION
Added hell_mv:
Instead of mv only one file to a destination file, all files in the destination folder are also mv-ed. Only files with matching extension are mv-ed. 
for example:
directory has a.txt b.txt c.txt d.bin e.pdf h.txt
call: mv1 h.txt t.txt

result:
directory now has: t3.txt t4.txt t1.txt d.bin e.pdf t2.txt

Currently works only when the destination and source folders are ./ 